### PR TITLE
Add missing dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@types/semver": "^5.4.0",
     "app-root-path": "^2.0.1",
     "babel-generator": "^6.26.1",
+    "babel-traverse": "^6.26.0",
+    "babylon": "^6.18.0",
     "javascript-obfuscator": "^0.13.0",
     "jju": "^1.3.0",
     "semver": "^5.4.1",


### PR DESCRIPTION
Hi!

Your library uses `babel-traverse` and `babylon` dependencies, but they are not listed in your `package.json`, so I have to add these dependencies explicitly to my project's `package.json` to build my project without errors.

This PR adds `babel-traverse` and `babylon` dependencies to `package.json`.

Thanks.