### PR TITLE
Feature: add an option that enables obfuscation for the specified platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ Iff true, enables obfuscation in development mode.
 
 #### Default value: `false`
 
+### `enableOnlyForPlatform: string | string[]`
+
+Enables obfuscation only for the specified platform.
+If falsy, enables obfuscation for all platforms.
+For example `['ios']` enables obfuscation only for IOS.
+
+#### Default value: `false`
+
 ## License
 
 MIT

--- a/src/getMetroTransformer.ts
+++ b/src/getMetroTransformer.ts
@@ -20,6 +20,7 @@ export interface MetroTransformer {
     src: string
     options: {
       dev?: boolean
+      platform?: string
       retainLines?: boolean
       // others unused
     }

--- a/src/obfuscatingTransformer.ts
+++ b/src/obfuscatingTransformer.ts
@@ -34,6 +34,7 @@ export interface ObfuscatingTransformerOptions {
   trace?: boolean
   emitObfuscatedFiles?: boolean
   enableInDevelopment?: boolean
+  enableOnlyForPlatform?: string | string[]
 }
 
 const sourceDir = path.join(appRootPath, "src")
@@ -59,6 +60,18 @@ export function obfuscatingTransformer({
 
       if (props.options.dev && !otherOptions.enableInDevelopment) {
         return result
+      }
+
+      if (otherOptions.enableOnlyForPlatform && props.options.platform) {
+        if (Array.isArray(otherOptions.enableOnlyForPlatform)) {
+          if (otherOptions.enableOnlyForPlatform.every(
+            platform => platform !== props.options.platform,
+          )) {
+            return result
+          }
+        } else if (otherOptions.enableOnlyForPlatform !== props.options.platform) {
+          return result
+        }
       }
 
       const resultCanBeObfuscated = result.code || result.ast


### PR DESCRIPTION
`enableOnlyForPlatform?: string | string[]`

Enables obfuscation only for the specified platform.
If falsy, enables obfuscation for all platforms.
For example `['ios']` enables obfuscation only for IOS.

Default value: `false`
