### PR TITLE
Support for RN >= 0.59

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ jspm_packages/
 dist
 package
 *.tar.gz
+
+# IntelliJ
+.idea

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ or
 
 ## Usage
 
-### /metro.config.js
+### React Native >= 0.59
+
+#### /metro.config.js
 
 ```diff
  module.exports = {
@@ -22,7 +24,29 @@ or
  }
 ```
 
-### /transformer.js
+#### /transformer.js
+
+```js
+const obfuscatingTransformer = require("react-native-obfuscating-transformer")
+
+module.exports = obfuscatingTransformer({
+  /* options */
+})
+```
+
+### React Native < 0.59
+
+### /rn-cli.config.js
+
+```diff
+ module.exports = {
++  transformer {
++    babelTransformerPath: require.resolve("./transformer")
++  },
+ }
+```
+
+#### /transformer.js
 
 ```js
 const obfuscatingTransformer = require("react-native-obfuscating-transformer")

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or
 
 ```diff
  module.exports = {
-+  transformer {
++  transformer: {
 +    babelTransformerPath: require.resolve("./transformer")
 +  },
  }
@@ -40,7 +40,7 @@ module.exports = obfuscatingTransformer({
 
 ```diff
  module.exports = {
-+  transformer {
++  transformer: {
 +    babelTransformerPath: require.resolve("./transformer")
 +  },
  }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ or
 
 ## Usage
 
-### /rn-cli.config.js
+### /metro.config.js
 
 ```diff
  module.exports = {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@types/app-root-path": "^1.2.4",
     "@types/babel-core": "^6.25.3",
     "@types/babel-generator": "^6.25.1",
+    "babel-traverse": "^6.26.0",
+    "babylon": "^6.18.0",
     "@types/node": "^9.3.0",
     "@types/semver": "^5.4.0",
     "app-root-path": "^2.0.1",

--- a/src/getMetroTransformer.ts
+++ b/src/getMetroTransformer.ts
@@ -44,7 +44,9 @@ function getReactNativeMinorVersion(): number {
 export function getMetroTransformer(
   reactNativeMinorVersion: number = getReactNativeMinorVersion(),
 ): MetroTransformer {
-  if (reactNativeMinorVersion >= 56) {
+  if (reactNativeMinorVersion >= 59) {
+    return require('metro-react-native-babel-transformer/src/index')
+  } else if (reactNativeMinorVersion >= 56) {
     return require("metro/src/reactNativeTransformer")
   } else if (reactNativeMinorVersion >= 52) {
     return require("metro/src/transformer")


### PR DESCRIPTION
Regarding to https://github.com/javascript-obfuscator/react-native-obfuscating-transformer/issues/10 this library doesn't support RN >= 0.59.
The included changes made it work for me with RN 0.60.3 again. Please review and merge if possible.

BR