### PR TITLE
`constructor arguments in the derived class t must be >= than ...` problem fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-generator": "^6.26.1",
     "babel-traverse": "^6.26.0",
     "babylon": "^6.18.0",
-    "javascript-obfuscator": "^0.13.0",
+    "javascript-obfuscator": "^2.6.0",
     "jju": "^1.3.0",
     "semver": "^5.4.1",
     "source-map": "^0.6.1"


### PR DESCRIPTION
The below issue fixed in this pull request.

https://github.com/javascript-obfuscator/react-native-obfuscating-transformer/issues/35